### PR TITLE
Add some game metadata

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -357,8 +357,8 @@ local function export_samples()
 			local settings = combinator.settings
 			if settings.name then
 				local entity_data = {
-                    id = entity.unit_number,
-                    surface = entity.surface.name,
+                    unit_number = entity.unit_number,
+                    surface_index = entity.surface.index,
 					settings = settings,
 				}
 				local red = entity.get_circuit_network(defines.wire_type.red, defines.circuit_connector_id.combinator_input)

--- a/control.lua
+++ b/control.lua
@@ -346,6 +346,7 @@ end
 local function export_samples()
     local samples = {
         entities = {},
+        ticks = game.ticks_played,
     }
     local invalid_unit_numbers = {}
 	for unit_number, combinator in pairs(global.statsd_combinators) do
@@ -356,6 +357,8 @@ local function export_samples()
 			local settings = combinator.settings
 			if settings.name then
 				local entity_data = {
+                    id = entity.unit_number,
+                    surface = entity.surface.name,
 					settings = settings,
 				}
 				local red = entity.get_circuit_network(defines.wire_type.red, defines.circuit_connector_id.combinator_input)


### PR DESCRIPTION
Adds some data to the samples dump to help other kinds of forwarder:

* the tick count, so we have a sense of absolute game time
* the entity ID of the combinator, so duplicate names can be tracked, if reasonable
* the surface name of the combinator

closes #4

closes #5 